### PR TITLE
Fixed wrong method used in main() method example

### DIFF
--- a/jewelcli/src/site/apt/usage-instance.apt
+++ b/jewelcli/src/site/apt/usage-instance.apt
@@ -101,7 +101,7 @@ public static void main(String [] args)
 {
   try
   {
-    MyExample result = CliFactory.createCliUsingInstance(new MyExample(), args);
+    MyExample result = CliFactory.parseArgumentsUsingInstance(new MyExample(), args);
     [...]
   }
   catch(ArgumentValidationException e)


### PR DESCRIPTION
In order to accept the args array, need to use parseArgumentsUsingInstance instead of createCliUsingInstance.
