### PR TITLE
Fix Issue #24: help options sorted by name, not method name

### DIFF
--- a/jewelcli/src/main/java/com/lexicalscope/jewel/cli/OptionsSpecificationImpl.java
+++ b/jewelcli/src/main/java/com/lexicalscope/jewel/cli/OptionsSpecificationImpl.java
@@ -50,6 +50,8 @@ class OptionsSpecificationImpl<O> implements OptionsSpecification<O>, CliSpecifi
             new HashMap<FluentMethod, UnparsedOptionSpecification>();
     private final Map<FluentMethod, UnparsedOptionSpecification> unparsedOptionalOptionsMethod =
             new HashMap<FluentMethod, UnparsedOptionSpecification>();
+    
+    private final OptionOrder ordering;
 
     OptionsSpecificationImpl(
             final FluentClass<O> klass,
@@ -57,13 +59,14 @@ class OptionsSpecificationImpl<O> implements OptionsSpecification<O>, CliSpecifi
             final List<UnparsedOptionSpecification> unparsedSpecifications) {
         this.klass = klass;
 
-        if(klass.annotatedWith(CommandLineInterface.class) &&
-           klass.annotation(CommandLineInterface.class).order().equals(OptionOrder.DEFINITION))
-        {
-            options = new LinkedHashSet<ParsedOptionSpecification>();
+        if (klass.annotatedWith(CommandLineInterface.class)) {
+            this.ordering = klass.annotation(CommandLineInterface.class).order();
+        } else {
+            this.ordering = OptionOrder.LEXICOGRAPHIC;
         }
-        else
-        {
+        if (OptionOrder.DEFINITION.equals(this.ordering)) {
+            options = new LinkedHashSet<ParsedOptionSpecification>();
+        } else {
             options = new TreeSet<ParsedOptionSpecification>();
         }
 
@@ -189,15 +192,17 @@ class OptionsSpecificationImpl<O> implements OptionsSpecification<O>, CliSpecifi
         helpMessage.startOfOptions();
 
         final List<ParsedOptionSpecification> sortedOptions = new ArrayList<ParsedOptionSpecification>(options);
-        Collections.sort(sortedOptions, new Comparator<ParsedOptionSpecification>() {
-            @Override
-            public int compare(ParsedOptionSpecification o1,
-                    ParsedOptionSpecification o2) {
-                final String o1Name = o1.getLongName().get(0);
-                final String o2Name = o2.getLongName().get(0);
-                return o1Name.compareTo(o2Name);
-            }
-        });
+        if (OptionOrder.LEXICOGRAPHIC.equals(this.ordering)) {
+            Collections.sort(sortedOptions, new Comparator<ParsedOptionSpecification>() {
+                @Override
+                public int compare(ParsedOptionSpecification o1,
+                        ParsedOptionSpecification o2) {
+                    final String o1Name = o1.getLongName().get(0);
+                    final String o2Name = o2.getLongName().get(0);
+                    return o1Name.compareTo(o2Name);
+                }
+            });
+        }
         for (final ParsedOptionSpecification specification : sortedOptions) {
             if (!specification.isHidden()) {
                 new ParsedOptionSummary(specification).describeOptionTo(helpMessage.option());

--- a/jewelcli/src/main/java/com/lexicalscope/jewel/cli/OptionsSpecificationImpl.java
+++ b/jewelcli/src/main/java/com/lexicalscope/jewel/cli/OptionsSpecificationImpl.java
@@ -186,11 +186,19 @@ class OptionsSpecificationImpl<O> implements OptionsSpecification<O>, CliSpecifi
 
         helpMessage.startOfOptions();
 
-        for (final ParsedOptionSpecification specification : options) {
-            if(!specification.isHidden())
-            {
-                new ParsedOptionSummary(specification).describeOptionTo(helpMessage.option());
+        ParsedOptionSpecification helpOption = null;
+        for (final Map.Entry<String, ParsedOptionSpecification> optionEntry : optionsByName.entrySet()) {
+            final ParsedOptionSpecification specification = optionEntry.getValue();
+            if (!specification.isHidden()) {
+                if (specification.isHelpOption()) {
+                    helpOption = specification;
+                } else {
+                    new ParsedOptionSummary(specification).describeOptionTo(helpMessage.option());
+                }
             }
+        }
+        if (helpOption != null) {
+            new ParsedOptionSummary(helpOption).describeOptionTo(helpMessage.option());
         }
 
         helpMessage.endOfOptions();

--- a/jewelcli/src/main/java/com/lexicalscope/jewel/cli/OptionsSpecificationImpl.java
+++ b/jewelcli/src/main/java/com/lexicalscope/jewel/cli/OptionsSpecificationImpl.java
@@ -15,6 +15,8 @@
 package com.lexicalscope.jewel.cli;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -186,19 +188,20 @@ class OptionsSpecificationImpl<O> implements OptionsSpecification<O>, CliSpecifi
 
         helpMessage.startOfOptions();
 
-        ParsedOptionSpecification helpOption = null;
-        for (final Map.Entry<String, ParsedOptionSpecification> optionEntry : optionsByName.entrySet()) {
-            final ParsedOptionSpecification specification = optionEntry.getValue();
-            if (!specification.isHidden()) {
-                if (specification.isHelpOption()) {
-                    helpOption = specification;
-                } else {
-                    new ParsedOptionSummary(specification).describeOptionTo(helpMessage.option());
-                }
+        final List<ParsedOptionSpecification> sortedOptions = new ArrayList<ParsedOptionSpecification>(options);
+        Collections.sort(sortedOptions, new Comparator<ParsedOptionSpecification>() {
+            @Override
+            public int compare(ParsedOptionSpecification o1,
+                    ParsedOptionSpecification o2) {
+                final String o1Name = o1.getLongName().get(0);
+                final String o2Name = o2.getLongName().get(0);
+                return o1Name.compareTo(o2Name);
             }
-        }
-        if (helpOption != null) {
-            new ParsedOptionSummary(helpOption).describeOptionTo(helpMessage.option());
+        });
+        for (final ParsedOptionSpecification specification : sortedOptions) {
+            if (!specification.isHidden()) {
+                new ParsedOptionSummary(specification).describeOptionTo(helpMessage.option());
+            }
         }
 
         helpMessage.endOfOptions();

--- a/jewelcli/src/main/java/com/lexicalscope/jewel/cli/specification/ParsedOptionSpecification.java
+++ b/jewelcli/src/main/java/com/lexicalscope/jewel/cli/specification/ParsedOptionSpecification.java
@@ -40,7 +40,7 @@ public interface ParsedOptionSpecification extends OptionSpecification {
     /**
      * Does this option have a Short Name
      *
-     * @return true iff the options has a short name
+     * @return true if the options has a short name
      */
     boolean hasShortName();
 
@@ -64,14 +64,14 @@ public interface ParsedOptionSpecification extends OptionSpecification {
     /**
      * Does the option take any arguments?
      *
-     * @return True iff the the option takes at least one argument
+     * @return True if the the option takes at least one argument
      */
     boolean hasValue();
 
     /**
      * Is this option a request for help
      *
-     * @return True iff this option is a request for help
+     * @return True if this option is a request for help
      */
     boolean isHelpOption();
 

--- a/jewelcli/src/test/java/com/lexicalscope/jewel/cli/examples/TestHelpExample.java
+++ b/jewelcli/src/test/java/com/lexicalscope/jewel/cli/examples/TestHelpExample.java
@@ -16,9 +16,9 @@ public class TestHelpExample {
                             "The options available are:",
                             "\t--count value",
                             "\t--email /^[^\\S@]+@[\\w.]+$/ : your email address",
+                            "\t--firstLongName --secondLongName -m -n value : many aliases",
                             "\t[--help -h] : display help",
                             "\t--location value : the location of something",
-                            "\t--firstLongName --secondLongName -m -n value : many aliases",
                             "\t--pattern -p value : a pattern");
 
     @Test public void testHelpExample() {

--- a/jewelcli/src/test/java/com/lexicalscope/jewel/cli/examples/TestHelpMessageOrder.java
+++ b/jewelcli/src/test/java/com/lexicalscope/jewel/cli/examples/TestHelpMessageOrder.java
@@ -38,6 +38,18 @@ public class TestHelpMessageOrder {
         @Option(helpRequest = true)
         boolean getHelp();
     }
+    
+    interface LexicographicOrderWithLongName
+    {
+        @Option(longName = "aardvark")
+        int getB();
+
+        @Option(longName = "zebra")
+        int getA();
+
+        @Option(helpRequest = true)
+        boolean getHelp();
+    }
 
     @CommandLineInterface(order = OptionOrder.DEFINITION)
     interface DefinitionOrder
@@ -57,6 +69,14 @@ public class TestHelpMessageOrder {
         assertThat(createCli(LexicographicOrder.class).getHelpMessage(), containsString(String.format("%s%n\t%s", "--a value", "--b value")));
     }
 
+    @Test public void lexicographicOrderWithLongNameSupported()
+    {
+        assertThat(
+    		createCli(LexicographicOrderWithLongName.class).getHelpMessage(), 
+    		containsString(String.format("%s%n\t%s", "--aardvark value", "--zebra value"))
+		);
+    }
+    
     @Test public void definitionOrderSupported()
     {
     	// in recent versions of the JDK, definition order is unreliable

--- a/jewelcli/src/test/java/com/lexicalscope/jewel/cli/examples/TestHelpMessageOrder.java
+++ b/jewelcli/src/test/java/com/lexicalscope/jewel/cli/examples/TestHelpMessageOrder.java
@@ -44,7 +44,7 @@ public class TestHelpMessageOrder {
         @Option(longName = "aardvark")
         int getB();
 
-        @Option(longName = "zebra")
+        @Option(longName = "echidna")
         int getA();
 
         @Option(helpRequest = true)
@@ -71,9 +71,10 @@ public class TestHelpMessageOrder {
 
     @Test public void lexicographicOrderWithLongNameSupported()
     {
+        
         assertThat(
     		createCli(LexicographicOrderWithLongName.class).getHelpMessage(), 
-    		containsString(String.format("%s%n\t%s", "--aardvark value", "--zebra value"))
+    		containsString(String.format("%s%n\t%s", "--aardvark value", "--echidna value"))
 		);
     }
     

--- a/jewelcli/src/test/java/com/lexicalscope/jewel/cli/examples/TestRmClassExample.java
+++ b/jewelcli/src/test/java/com/lexicalscope/jewel/cli/examples/TestRmClassExample.java
@@ -32,11 +32,11 @@ public class TestRmClassExample {
         assertEquals(
                 UtilitiesForTesting.joinLines(
                         "Usage: rm [options] FILE...",
+                        "\t[--directory -d] : unlink FILE, even if it is a non-empty directory (super-user only)",
                         "\t[--force -f] : ignore nonexistent files, never prompt",
                         "\t[--help] : display this help and exit",
                         "\t[--interactive -i] : prompt before any removal",
                         "\t[--recursive -r -R] : remove the contents of directories recursively",
-                        "\t[--directory -d] : unlink FILE, even if it is a non-empty directory (super-user only)",
                         "\t[--verbose -v] : explain what is being done",
                         "\t[--version] : output version information and exit"), result0.getHelpMessage());
     }

--- a/jewelcli/src/test/java/com/lexicalscope/jewel/cli/examples/TestRmExample.java
+++ b/jewelcli/src/test/java/com/lexicalscope/jewel/cli/examples/TestRmExample.java
@@ -30,11 +30,11 @@ public class TestRmExample {
         assertEquals(
                 UtilitiesForTesting.joinLines(
                         "Usage: rm [options] FILE...",
+                        "\t[--directory -d] : unlink FILE, even if it is a non-empty directory (super-user only)",
                         "\t[--force -f] : ignore nonexistent files, never prompt",
                         "\t[--help] : display this help and exit",
                         "\t[--interactive -i] : prompt before any removal",
                         "\t[--recursive -r -R] : remove the contents of directories recursively",
-                        "\t[--directory -d] : unlink FILE, even if it is a non-empty directory (super-user only)",
                         "\t[--verbose -v] : explain what is being done",
                         "\t[--version] : output version information and exit"), result0.getHelpMessage());
     }


### PR DESCRIPTION
Fix Issue #24: in the help message, options are now sorted by each option's first long name, not by the method name in the interface/bean.
